### PR TITLE
[PA-129] 이메일 코드 인증 시 id_token이 유효하지 않을 때 500 반환

### DIFF
--- a/utils/auth/kakao.py
+++ b/utils/auth/kakao.py
@@ -44,8 +44,12 @@ def validate_id_token(id_token: str) -> bool:
 
     url = 'https://kauth.kakao.com/.well-known/jwks.json'
 
-    jwks_client = PyJWKClient(url)
-    signing_key = jwks_client.get_signing_key_from_jwt(id_token)
+    try:
+        jwks_client = PyJWKClient(url)
+        signing_key = jwks_client.get_signing_key_from_jwt(id_token)
+    except jwt.exceptions.InvalidTokenError:
+        return False
+
     try:
         jwt.decode(
             id_token,


### PR DESCRIPTION
500 반환이 아닌 요청 실패를 반환하도록 수정