### PR TITLE
내 정보 보기 API URL 수정

### DIFF
--- a/apps/buyers/urls.py
+++ b/apps/buyers/urls.py
@@ -3,5 +3,5 @@ from django.urls import path
 from apps.buyers.views import BuyerMyInfoView
 
 urlpatterns = [
-    path('my', BuyerMyInfoView.as_view()),
+    path('info', BuyerMyInfoView.as_view()),
 ]

--- a/apps/sellers/urls.py
+++ b/apps/sellers/urls.py
@@ -10,11 +10,11 @@ from apps.sellers.views import (
 )
 
 urlpatterns = [
-    path('my', SellerMyInfoView.as_view()),
     path('register', SellerRegisterView.as_view()),
     path('verify', SellerVerifyView.as_view()),
     path('descriptions', SellerDescriptionView.as_view()),
     path('items', SellerItemView.as_view()),
     path('items/<str:item_id>', SellerItemView.as_view()),
-    path('<str:nickname>', SellerInfoView.as_view()),
+    path('info', SellerMyInfoView.as_view()),
+    path('info/<str:nickname>', SellerInfoView.as_view()),
 ]


### PR DESCRIPTION
기존 내 정보 보기 API는 `sellers/my`이고
판매자 정보 보기 API는 `sellers/{nickname}`이기에 my라는 닉네임을 가진 판매자의 정보를 정상적으로 처리할 수 없습니다.

`sellers/info`가 내 정보 보기 API이고
`sellers/info/{nickname}`이 다른 판매자 정보 보기 API로 url을 변경합니다.