### PR TITLE
[PA-284] 구매자 주문내역 API 수정

### DIFF
--- a/apps/buyers/serializers.py
+++ b/apps/buyers/serializers.py
@@ -16,3 +16,8 @@ class BuyerMyOrderSerializer(serializers.Serializer):
     ordered_datetime = serializers.DateTimeField()
     order_status = serializers.CharField(source='get_order_status_display')
     is_reviewed = serializers.BooleanField()
+    name = serializers.CharField()
+    address = serializers.CharField()
+    detail_address = serializers.CharField()
+    phone_number = serializers.CharField()
+    zipcode = serializers.CharField()

--- a/apps/buyers/serializers.py
+++ b/apps/buyers/serializers.py
@@ -1,3 +1,4 @@
+from phonenumber_field.serializerfields import PhoneNumberField
 from rest_framework import serializers
 
 
@@ -19,5 +20,5 @@ class BuyerMyOrderSerializer(serializers.Serializer):
     name = serializers.CharField()
     address = serializers.CharField()
     detail_address = serializers.CharField()
-    phone_number = serializers.CharField()
+    phone_number = PhoneNumberField(region='KR')
     zipcode = serializers.CharField()

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -979,3 +979,35 @@ paths:
                 out of stock:
                   value:
                     message: 재고가 부족합니다.
+
+  /orders/my:
+    get:
+      tags:
+        - buyers
+      summary: 구매자 주문 목록 조회
+      description: 구매자 주문 목록을 조회합니다.
+      security:
+          - leporemartTokenAuth: []
+      responses:
+        '200':
+          description: 구매자 주문 목록 조회 성공
+          content:
+            application/json:
+              example:
+                [
+                  {
+                    "order_id": 26,
+                    "item_id": 6,
+                    "item_title": "작품1",
+                    "item_thumbnail_image": "https://leporem-art-media-dev.s3.amazonaws.com/items/item_image/b377df95-1307-490f-baae-7e3def0a7fb9.jpg",
+                    "price": 10000,
+                    "ordered_datetime": "2023-10-24T07:09:55.397999Z",
+                    "order_status": "주문완료",
+                    "is_reviewed": false,
+                    "name": "홍길동",
+                    "address": "서울특별시 강남구 테헤란로 427",
+                    "detail_address": "7층",
+                    "phone_number": "+821012345678",
+                    "zipcode": "12345"
+                  }
+                ]

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -980,7 +980,7 @@ paths:
                   value:
                     message: 재고가 부족합니다.
 
-  /orders/my:
+  /buyers/orders/my:
     get:
       tags:
         - buyers


### PR DESCRIPTION
구매자 주문내역 API 수정합니다.
기존 필드에 다음의 필드들을 함께 조회할 수 있습니다.
- `name`: 주문자 성함
- `address`: 주문자 도로명 주소
- `detail_address`: 주문자 상세 주소
- `zipcode`: 주문자 우편번호
- `phone_number`: 주문자 휴대전화 번호