### PR TITLE
[PA-287] 판매자 주문목록 API 수정

### DIFF
--- a/apps/sellers/serializers.py
+++ b/apps/sellers/serializers.py
@@ -1,3 +1,4 @@
+from phonenumber_field.serializerfields import PhoneNumberField
 from rest_framework import serializers
 
 
@@ -57,6 +58,11 @@ class SellerMyOrderSerializer(serializers.Serializer):
     ordered_datetime = serializers.DateTimeField()
     order_status = serializers.CharField(source='get_order_status_display')
     buyer = serializers.CharField(source='buyer.user.nickname')
+    buyer_name = serializers.CharField(source='name')
+    address = serializers.CharField()
+    detail_address = serializers.CharField()
+    zipcode = serializers.CharField()
+    phone_number = PhoneNumberField(region='KR')
 
 
 class TransactionSerializer(serializers.Serializer):

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -979,3 +979,35 @@ paths:
                 out of stock:
                   value:
                     message: 재고가 부족합니다.
+
+  /sellers/orders/my:
+    get:
+      tags:
+        - sellers
+      summary: 판매자 주문 목록 조회
+      description: 판매자의 주문 목록을 조회합니다.
+      security:
+        - leporemartTokenAuth: []
+      responses:
+        '200':
+            description: 판매자 주문 목록 조회 성공
+            content:
+                application/json:
+                  example:
+                    [
+                      {
+                        "order_id": 23,
+                        "item_id": 4,
+                        "item_title": "test1",
+                        "item_thumbnail_image": "https://leporem-art-media-dev.s3.amazonaws.com/items/item_image/cinamoroll.jpeg",
+                        "price": 25000,
+                        "ordered_datetime": "2023-10-02T02:30:18.872108Z",
+                        "order_status": "배송중",
+                        "buyer": "ghdwnstlr",
+                        "buyer_name": "Unknown Name",
+                        "address": "Unknown Address",
+                        "detail_address": "",
+                        "zipcode": "00000",
+                        "phone_number": "01000000000"
+                      }
+                    ]

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1004,10 +1004,10 @@ paths:
                         "ordered_datetime": "2023-10-02T02:30:18.872108Z",
                         "order_status": "배송중",
                         "buyer": "ghdwnstlr",
-                        "buyer_name": "Unknown Name",
-                        "address": "Unknown Address",
-                        "detail_address": "",
-                        "zipcode": "00000",
-                        "phone_number": "01000000000"
+                        "buyer_name": "홍길동",
+                        "address": "서울특별시 강남구 테헤란로 427",
+                        "detail_address": "7층",
+                        "zipcode": "12345",
+                        "phone_number": "+921012345678"
                       }
                     ]


### PR DESCRIPTION
판매자 주문목록 API 수정합니다.
기존 필드와 함께 다음의 필드들을 함께 조회합니다.
- `buyer_name`: 주문자 성함
- `address`: 주문자 도로명 주소
- `detail_address`: 주문자 상세 주소
- `zipcode`: 주문자 우편번호
-`phone_number`: 주문자 휴대전화 번호