### PR TITLE
전시전 상태 변경

### DIFF
--- a/apps/exhibitions/repositories.py
+++ b/apps/exhibitions/repositories.py
@@ -192,5 +192,12 @@ class ExhibitionItemRepository:
             exhibition_item.item.delete()
         exhibition_item.delete()
 
+        exhibition = Exhibition.objects.get(exhibition_id=exhibition_item.exhibition.exhibition_id)
+        item_count = exhibition.exhibition_items.count()
+        if item_count == 0 and exhibition.status == Exhibition.Status.ITEM_REGISTERED.value:
+            exhibition.status = Exhibition.Status.ARTIST_WRITTEN.value
+
+        exhibition.save()
+
     def get_exhibition_item(self, exhibition_item_id):
         return ExhibitionItem.objects.get(exhibition_item_id=exhibition_item_id)

--- a/apps/exhibitions/repositories.py
+++ b/apps/exhibitions/repositories.py
@@ -127,6 +127,12 @@ class ExhibitionItemRepository:
             exhibition_item=exhibition_item,
             sound=sound,
         )
+
+        if exhibition.status == Exhibition.Status.ARTIST_WRITTEN.value:
+            exhibition.status = Exhibition.Status.ITEM_REGISTERED.value
+
+        exhibition.save()
+
         return exhibition_item
 
     @transaction.atomic


### PR DESCRIPTION
전시전 작품 등록, 삭제 시에 전시전 상태 변경합니다.
- 전시전 작품 삭제 시에는 작품 개수가 0개일 때, `ARTIST_WRITTEN` 상태로 돌아갑니다.