### PR TITLE
전시전 작품 수정 API 수정

### DIFF
--- a/apps/exhibitions/services.py
+++ b/apps/exhibitions/services.py
@@ -204,9 +204,8 @@ class ExhibitionItemService:
                 depth=None,
                 height=None,
             )
-            exhibition = ExhibitionRepository().get_exhibition(exhibition_id=exhibition_id)
-            item.start_date = exhibition.start_date
-            item.end_date = exhibition.end_date
+            item.start_date = exhibition_item.exhibition.start_date
+            item.end_date = exhibition_item.exhibition.end_date
             item.save()
             exhibition_item.item = item
             exhibition_item.save()

--- a/apps/exhibitions/services.py
+++ b/apps/exhibitions/services.py
@@ -213,6 +213,10 @@ class ExhibitionItemService:
 
     def delete(self, exhibition_item_id, user_id):
         exhibition_item = ExhibitionItemRepository().get_exhibition_item(exhibition_item_id)
-        if not exhibition_item.exhibition.seller.user_id == user_id:
+        if not exhibition_item.exhibition.seller.user == user_id:
             raise PermissionDenied('본인의 전시만 삭제할 수 있습니다.')
+        if exhibition_item.item:
+            ItemRepository().delete(
+                seller_id=exhibition_item.exhibition.seller.seller_id, item_id=exhibition_item.exhibition.item
+            )
         ExhibitionItemRepository().delete(exhibition_item_id)

--- a/apps/exhibitions/services.py
+++ b/apps/exhibitions/services.py
@@ -167,7 +167,7 @@ class ExhibitionItemService:
 
         images = [exhibition_image.image.open() for exhibition_image in exhibition_item.exhibition_images.all()]
 
-        if is_sale:
+        if exhibition_item.item and is_sale:
             ItemRepository().modify(
                 item_id=exhibition_item.item.item_id,
                 seller_id=seller_id,
@@ -184,6 +184,32 @@ class ExhibitionItemService:
                 depth=None,
                 height=None,
             )
+        elif exhibition_item.item and not is_sale:
+            ItemRepository().delete(seller_id=seller_id, item_id=exhibition_item.item.item_id)
+            exhibition_item.item = None
+            exhibition_item.save()
+        elif not exhibition_item.item and is_sale:
+            item = ItemRepository().register(
+                seller_id=seller_id,
+                price=price,
+                max_amount=current_amount,
+                title=title,
+                description=description,
+                shorts_url=shorts_url,
+                thumbnail_image=images[0],
+                images=images[1:],
+                categories=[],
+                colors=[],
+                width=None,
+                depth=None,
+                height=None,
+            )
+            exhibition = ExhibitionRepository().get_exhibition(exhibition_id=exhibition_id)
+            item.start_date = exhibition.start_date
+            item.end_date = exhibition.end_date
+            item.save()
+            exhibition_item.item = item
+            exhibition_item.save()
 
     def delete(self, exhibition_item_id, user_id):
         exhibition_item = ExhibitionItemRepository().get_exhibition_item(exhibition_item_id)


### PR DESCRIPTION
전시전 작품 수정 API 수정합니다.
다음의 경우를 고려합니다.
- 전시전 작품 판매 -> 미판매
- 전시전 작품 미판매 -> 미판매

전시전 작품 삭제 API 수정합니다.
- 전시전 작품 삭제 시에 판매 작품이 있다면, 함께 삭제합니다.