### PR TITLE
작품 삭제 API 수정

### DIFF
--- a/apps/exhibitions/services.py
+++ b/apps/exhibitions/services.py
@@ -216,6 +216,6 @@ class ExhibitionItemService:
             raise PermissionDenied('본인의 전시만 삭제할 수 있습니다.')
         if exhibition_item.item:
             ItemRepository().delete(
-                seller_id=exhibition_item.exhibition.seller.seller_id, item_id=exhibition_item.exhibition.item
+                seller_id=exhibition_item.exhibition.seller.seller_id, item_id=exhibition_item.item.item_id
             )
         ExhibitionItemRepository().delete(exhibition_item_id)

--- a/apps/exhibitions/services.py
+++ b/apps/exhibitions/services.py
@@ -218,4 +218,5 @@ class ExhibitionItemService:
             ItemRepository().delete(
                 seller_id=exhibition_item.exhibition.seller.seller_id, item_id=exhibition_item.item.item_id
             )
-        ExhibitionItemRepository().delete(exhibition_item_id)
+        deleted_position = exhibition_item.position
+        ExhibitionItemRepository().delete(exhibition_item_id, deleted_position)


### PR DESCRIPTION
작품 삭제 API 수정합니다.
작품 삭제 시, 삭제하는 작품의 `position`보다 큰 `position`을 가진 작품들은 `position-1`합니다.