### PR TITLE
판매자 온도 설정 수정

### DIFF
--- a/apps/exhibitions/services.py
+++ b/apps/exhibitions/services.py
@@ -5,10 +5,19 @@ from django.core.exceptions import PermissionDenied
 from apps.exhibitions.models import ExhibitionItemSound
 from apps.exhibitions.repositories import ExhibitionItemRepository, ExhibitionRepository
 from apps.items.repositories import ItemRepository
+from apps.sellers.repositories import SellerRepository
 from utils.files import create_presigned_url, create_random_filename
 
 
 class ExhibitionService:
+    def register(self, nickname, start_date, end_date):
+        exhibition = ExhibitionRepository().register(
+            nickname=nickname,
+            start_date=start_date,
+            end_date=end_date,
+        )
+        SellerRepository().change_temperature(exhibition.seller.seller_id, 5)
+
     def register_artist_info(
         self,
         exhibition_id,

--- a/apps/exhibitions/services.py
+++ b/apps/exhibitions/services.py
@@ -121,6 +121,8 @@ class ExhibitionItemService:
             exhibition_item.item = item
             exhibition_item.save()
 
+            SellerRepository().change_temperature(seller_id, 0.5)
+
     def get_presigned_url_to_post_sound(self, extension='mp3'):
         return create_presigned_url(f'{ExhibitionItemSound.sound.field.upload_to}{str(uuid.uuid4())}.{extension}')
 
@@ -197,6 +199,7 @@ class ExhibitionItemService:
             ItemRepository().delete(seller_id=seller_id, item_id=exhibition_item.item.item_id)
             exhibition_item.item = None
             exhibition_item.save()
+            SellerRepository().change_temperature(seller_id, -0.5)
         elif not exhibition_item.item and is_sale:
             item = ItemRepository().register(
                 seller_id=seller_id,
@@ -229,3 +232,5 @@ class ExhibitionItemService:
             )
         deleted_position = exhibition_item.position
         ExhibitionItemRepository().delete(exhibition_item_id, deleted_position)
+
+        SellerRepository().change_temperature(exhibition_item.exhibition.seller.seller_id, -0.5)

--- a/apps/exhibitions/services.py
+++ b/apps/exhibitions/services.py
@@ -221,6 +221,7 @@ class ExhibitionItemService:
             item.save()
             exhibition_item.item = item
             exhibition_item.save()
+            SellerRepository().change_temperature(seller_id, 0.5)
 
     def delete(self, exhibition_item_id, user_id):
         exhibition_item = ExhibitionItemRepository().get_exhibition_item(exhibition_item_id)

--- a/apps/exhibitions/views.py
+++ b/apps/exhibitions/views.py
@@ -29,7 +29,7 @@ class ExhibitionView(APIView):
     def post(self, request):
         serializer = self.serializer_class(data=request.data)
         if serializer.is_valid(raise_exception=True):
-            ExhibitionRepository().register(
+            ExhibitionService().register(
                 nickname=serializer.validated_data['nickname'],
                 start_date=serializer.validated_data['start_date'],
                 end_date=serializer.validated_data['end_date'],

--- a/apps/sellers/services.py
+++ b/apps/sellers/services.py
@@ -67,6 +67,7 @@ class SellerService:
             categories=categories,
             colors=colors,
         )
+        SellerRepository().change_temperature(seller_id, 0.5)
 
     def modify_item(
         self,
@@ -119,10 +120,7 @@ class SellerService:
         item_repository = ItemRepository()
         item_repository.change_current_amount(item_id, seller_id, action)
 
-    def change_temperature(self, seller_id, number):
-        seller_repository = SellerRepository()
-        seller_repository.change_temperature(seller_id, number)
-
     def delete_item(self, seller_id, item_id):
         item_repository = ItemRepository()
         item_repository.delete(seller_id, item_id)
+        SellerRepository().change_temperature(seller_id, -0.5)

--- a/apps/sellers/views.py
+++ b/apps/sellers/views.py
@@ -83,8 +83,6 @@ class SellerItemView(APIView):
                 categories=serializer.validated_data.get('categories', []),
                 colors=serializer.validated_data.get('colors', []),
             )
-            seller_service = SellerService()
-            seller_service.change_temperature(request.user.seller.seller_id, 0.5)
             return Response({'message': 'success'})
 
     def patch(self, request, *args, **kwargs):


### PR DESCRIPTION
판매자 온도 설정 수정 및 추가합니다.
- 판매자 작품 등록 시에 온도 설정을 `view` -> `service`에서 하는 것으로 변경합니다.
- 판매자 작품 삭제 시에 온도가 -0.5 되도록 추가합니다.
- 판매자 전시전 등록 시에 온도가 +5 되도록 추가합니다.